### PR TITLE
本番で使わないパッケージをdevdependenciesへ移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,37 @@
 {
-    "name": "scamper",
-    "version": "1.0.0",
-    "main": "index.js",
-    "scripts": {
-        "start": "webpack-dev-server --port 4000 --content-base public",
-        "build": "webpack -p"
-    },
-    "//": {
-        "start": "demo at http://localhost:4000",
-        "build": "generate ./public/scamper.js"
-    },
-    "license": "MIT",
-    "dependencies": {
-        "babel-core": "^6.26.3",
-        "babel-loader": "7",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-react": "^6.24.1",
-        "css-loader": "^2.1.1",
-        "file-loader": "^3.0.1",
-        "js-yaml-loader": "^1.0.1",
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0",
-        "react-redux": "^7.0.3",
-        "redux": "^4.0.1",
-        "redux-devtools": "^3.5.0",
-        "semantic-ui-css": "^2.4.1",
-        "semantic-ui-react": "^0.87.1",
-        "style-loader": "^0.23.1",
-        "url-loader": "^1.1.2",
-        "webpack": "^4.31.0",
-        "webpack-cli": "^3.3.2",
-        "webpack-dev-server": "^3.4.1"
-    }
+  "name": "scamper",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --port 4000 --content-base public",
+    "build": "webpack -p"
+  },
+  "//": {
+    "start": "demo at http://localhost:4000",
+    "build": "generate ./public/scamper.js"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-redux": "^7.0.3",
+    "redux": "^4.0.1",
+    "redux-devtools": "^3.5.0",
+    "semantic-ui-css": "^2.4.1",
+    "semantic-ui-react": "^0.87.1"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-loader": "7",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "css-loader": "^2.1.1",
+    "file-loader": "^3.0.1",
+    "js-yaml-loader": "^1.0.1",
+    "style-loader": "^0.23.1",
+    "url-loader": "^1.1.2",
+    "webpack": "^4.31.0",
+    "webpack-cli": "^3.3.2",
+    "webpack-dev-server": "^3.4.1"
+  }
 }


### PR DESCRIPTION
https://github.com/t-morisawa/scamper/issues/11

 - アプリ内でimportしているライブラリについてはdependenciesに残して、他は移動
 - 普通に `yarn install` する場合は全てインストールされるので、挙動の変化はなし
 - バンドル後のJSが重いという問題は未解決
