### PR TITLE
プレゼンテーショナルコンポーネントをシンプルにする（main編）

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,9 +1,8 @@
-import yaml from './yaml-parser';
+import yaml from './data.yml';
 
 const item = yaml[IDEA_TYPE];
 const title = item.title;
 const description = item.description;
-const list = item.data;
+const data = item.data;
 
-export { title , description };
-export const data = list;
+export { title, description, data };

--- a/src/constants/yaml-parser.js
+++ b/src/constants/yaml-parser.js
@@ -1,3 +1,0 @@
-import yaml from './data.yml';
-
-export default yaml;

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -3,30 +3,34 @@ import { connect } from 'react-redux'
 import Opening from '../presentationals/Opening'
 import Interaction from '../presentationals/Interaction'
 import ResultView from '../presentationals/ResultView'
-import { data } from '../constants';
 import LoaderExampleText from '../presentationals/LoadSampleText';
+import { title, description, data } from '../constants'
 
 let AppContainer = ({ index, isStart }) => {
-    if ( isStart === false ) {
-        return(
-            <Opening />
-        )
-    }
-    else if ( index === data.length ) {
-        return (
-                <ResultView />
-        )
-    }
-    return  (
-            <Interaction index={ index }/>
+
+  if ( isStart === false ) {
+    return(
+        <Opening title={title} description={description} />
     )
+  } else if ( index === data.length ) {
+    return (
+        <ResultView />
+    )
+  } else {
+    const theme = data[index].title;
+    const question = data[index].description;
+
+    return  (
+        <Interaction theme={theme} question={question} />
+    )
+  }
 }
 
 const mapStateToProps = (state) => (
-    {
-        index: state.main.index,
-        isStart: state.home.isStart,
-    })
+  {
+    index: state.main.index,
+    isStart: state.home.isStart,
+  })
 
 AppContainer = connect(mapStateToProps)(AppContainer)
 

--- a/src/presentationals/Explanation.js
+++ b/src/presentationals/Explanation.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Container } from 'semantic-ui-react'
 import { List } from 'semantic-ui-react'
-import { title, description } from '../constants'
 
-const Explanation = () => {
+const Explanation = ({ description }) => {
   return (
       <div>
         {description.split("\n").map((m, index) => {

--- a/src/presentationals/Interaction.js
+++ b/src/presentationals/Interaction.js
@@ -1,14 +1,10 @@
 import React from 'react'
 import Theme from '../presentationals/Theme'
 import Question from '../presentationals/Question'
-import { data, description } from '../constants'
 import ReduxForm from '../containers/ReduxForm.js'
 import { Container, Header } from 'semantic-ui-react'
 
-let Interaction = ({ index }) => {
-  const theme = data[index].title;
-  const question = data[index].description;
-
+let Interaction = ({ theme, question }) => {
     return (
             <Container style={{ marginTop: '2em' }}>
             <Theme theme={theme}/>

--- a/src/presentationals/Opening.js
+++ b/src/presentationals/Opening.js
@@ -2,18 +2,15 @@ import React, { Component } from 'react'
 import { Container, Header } from 'semantic-ui-react'
 import Start from '../containers/Start'
 import Explanation from './Explanation'
-import { title } from '../constants'
 
-class Opening extends Component {
-    render() {
-        return (
-                <Container style={{ marginTop: '2em' }}>
-                <Header as='h1'>{title}</Header>
-                <Explanation />
-                <Start />
-                </Container>
-        )
-    }
+const Opening = ({ title, description }) => {
+  return (
+      <Container style={{ marginTop: '2em' }}>
+      <Header as='h1'>{title}</Header>
+      <Explanation description={description} />
+      <Start />
+      </Container>
+  )
 }
 
 export default Opening


### PR DESCRIPTION
# 背景
https://github.com/t-morisawa/scamper/issues/12

# やったこと
presentational componentsは、propsを受け取って表示するだけにする

# 残件
result編に続く