### PR TITLE
アプリのルートコンポーネントをReactDOM.renderメソッドから外出しする

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,8 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { createStore } from 'redux'
-import { Provider } from 'react-redux'
-import AppContainer from './containers/AppContainer'
-import reducer from './reducers'
-import 'semantic-ui-css/semantic.min.css';
-
-const store = createStore(
-    reducer,
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-)
+import Root from './presentationals/Root'
 
 render(
-        <Provider store={store}>
-        <AppContainer />
-        </Provider>,
+    <Root />,
     document.getElementById('root')
 )

--- a/src/presentationals/Root.js
+++ b/src/presentationals/Root.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import AppContainer from '../containers/AppContainer'
+import reducer from '../reducers'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+import 'semantic-ui-css/semantic.min.css';
+
+const store = createStore(
+  reducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+)
+
+let Root = () => {
+  return  (
+      <Provider store={store}>
+      <AppContainer />
+      </Provider>
+  )
+}
+
+export default Root


### PR DESCRIPTION
# 背景
- idea-factoryのコンポーネントからscamperアプリのコンポーネントを読み込んで使えるようにしたい
- これまではReactDOMと密結合だったためそれができていなかった

# やること
`Root` コンポーネントを定義し、それを読み込むことで任意のReactコンポーネントからscamperアプリを使えるようにする

# メモ
Rootコンポーネントでやること
 - Redux Storeの定義
 - CSS(semantic UI)の定義
 - アプリ(AppContainer)のrender